### PR TITLE
Add PHP 8.4 support and require PHP 8.3+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: [ '8.2', '8.3' ]
+        php-versions: ['8.3', '8.4']
         dependency-versions: [ 'highest', 'lowest' ]
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "phpstan/phpstan-symfony": "^1.3.7"
   },
   "require": {
-    "php": "^8.2",
+    "php": "^8.3",
     "symfony/cache": "^6.0|^7.0",
     "symfony/contracts": "^2.5|^3.4",
     "phpmailer/phpmailer": "^6.6",

--- a/src/Dto/InvalidAddressDto.php
+++ b/src/Dto/InvalidAddressDto.php
@@ -13,7 +13,7 @@ class InvalidAddressDto implements ValidationStatusDtoInterface
     private string $reason;
     private ?string $smtpResponse;
 
-    private function __construct(string $email, string $reason, string $smtpResponse = null)
+    private function __construct(string $email, string $reason, ?string $smtpResponse = null)
     {
         $this->email = $email;
         $this->reason = $reason;

--- a/src/Translatable/BounceReasonTranslatable.php
+++ b/src/Translatable/BounceReasonTranslatable.php
@@ -24,7 +24,7 @@ class BounceReasonTranslatable implements TranslatableInterface
         $this->translationKeys = $this->getTranslationKey($reason);
     }
 
-    public function trans(TranslatorInterface $translator, string $locale = null): string
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
         return implode('', array_filter([
             $translator->trans('bounce.reason.' . $this->translationKeys[0], [], 'assoconnect_smtp_toolbox'),

--- a/src/Translatable/InvalidAddressTranslatable.php
+++ b/src/Translatable/InvalidAddressTranslatable.php
@@ -22,7 +22,7 @@ class InvalidAddressTranslatable implements TranslatableInterface
         $this->smtpResponse = $smtpResponse;
     }
 
-    public function trans(TranslatorInterface $translator, string $locale = null): string
+    public function trans(TranslatorInterface $translator, ?string $locale = null): string
     {
         return $translator->trans(
             'invalid_address.' . $this->reason,


### PR DESCRIPTION
## Summary
- Update minimum PHP requirement to 8.3
- Add PHP 8.4 to CI test matrix

## Changes
- Update composer.json to require PHP ^8.3
- Update GitHub Actions workflow to test on PHP 8.3 and 8.4

## Related
Part of organization-wide upgrade to standardize on PHP 8.3+ across all packages.

## Test plan
- [ ] CI tests pass on PHP 8.3
- [ ] CI tests pass on PHP 8.4