### PR TITLE
Apply Rector fixes: make data providers static

### DIFF
--- a/tests/Resolver/BounceTypeResolverTest.php
+++ b/tests/Resolver/BounceTypeResolverTest.php
@@ -17,7 +17,7 @@ class BounceTypeResolverTest extends TestCase
         self::assertEquals($expected, $resolver->resolve($bounceReason));
     }
 
-    public function provideBounceReasons(): iterable
+    public static function provideBounceReasons(): iterable
     {
         yield 'DMarc failure' => [BounceTypeResolver::BOUNCE_REASON_DMARC_FAILURE, 'Email rejected per DMARC policy'];
         yield 'Blacklisted' => [BounceTypeResolver::BOUNCE_REASON_BLACKLISTED, 'LPN007_510'];

--- a/tests/Resolver/ProviderResolverTest.php
+++ b/tests/Resolver/ProviderResolverTest.php
@@ -22,7 +22,7 @@ class ProviderResolverTest extends TestCase
         self::assertSame($provider, $resolver->resolve($address));
     }
 
-    public function provideAddressesAndProviders(): iterable
+    public static function provideAddressesAndProviders(): iterable
     {
         // Without DNS check
         yield ['john@hotmail.com', 'microsoft'];

--- a/tests/Specification/BounceIsCausedByInactiveUserSpecificationTest.php
+++ b/tests/Specification/BounceIsCausedByInactiveUserSpecificationTest.php
@@ -17,7 +17,7 @@ class BounceIsCausedByInactiveUserSpecificationTest extends TestCase
     }
 
     /** @return array{string, bool}[] */
-    public function provideMessages(): iterable
+    public static function provideMessages(): iterable
     {
         yield ['Email rejected per SPAM policy', false];
         yield [

--- a/tests/Specification/BounceIsCausedByOverQuotaSpecificationTest.php
+++ b/tests/Specification/BounceIsCausedByOverQuotaSpecificationTest.php
@@ -17,7 +17,7 @@ class BounceIsCausedByOverQuotaSpecificationTest extends TestCase
     }
 
     /** @return array{string, bool}[] */
-    public function provideMessages(): iterable
+    public static function provideMessages(): iterable
     {
         yield ['Email rejected per SPAM policy', false];
         yield [

--- a/tests/Specification/BounceIsCausedByUnknownUserSpecificationTest.php
+++ b/tests/Specification/BounceIsCausedByUnknownUserSpecificationTest.php
@@ -17,7 +17,7 @@ class BounceIsCausedByUnknownUserSpecificationTest extends TestCase
     }
 
     /** @return array{string, bool}[] */
-    public function provideMessages(): iterable
+    public static function provideMessages(): iterable
     {
         yield ['Email rejected per SPAM policy', false];
         yield ['Sender address rejected: Sender user unknown.  Adresse expediteur inconnue', true];

--- a/tests/Specification/BounceIsSpamRelatedSpecificationTest.php
+++ b/tests/Specification/BounceIsSpamRelatedSpecificationTest.php
@@ -18,7 +18,7 @@ class BounceIsSpamRelatedSpecificationTest extends TestCase
     }
 
     /** @return array{string, bool}[] */
-    public function provideMessages(): iterable
+    public static function provideMessages(): iterable
     {
         yield ['Email rejected per SPAM policy', true];
         yield ['Sender address rejected: Sender user unknown.  Adresse expediteur inconnue', false];

--- a/tests/Specification/BounceReasonIsUnknownSpecificationTest.php
+++ b/tests/Specification/BounceReasonIsUnknownSpecificationTest.php
@@ -17,7 +17,7 @@ class BounceReasonIsUnknownSpecificationTest extends TestCase
     }
 
     /** @return array{string, bool}[] */
-    public function provideMessages(): iterable
+    public static function provideMessages(): iterable
     {
         yield ['hard bounce', true];
         yield ['Sender address rejected: Sender user unknown.  Adresse expediteur inconnue', false];

--- a/tests/Specification/EmailAddressIsFromACountrySpecificationTest.php
+++ b/tests/Specification/EmailAddressIsFromACountrySpecificationTest.php
@@ -22,7 +22,7 @@ class EmailAddressIsFromACountrySpecificationTest extends TestCase
         self::assertSame($isSatisfiedBy, $spec->isSatisfiedBy($emailAddress, $country));
     }
 
-    public function provideEmailAddresses(): iterable
+    public static function provideEmailAddresses(): iterable
     {
         // Invalid
         yield ['hello', 'FR', false];

--- a/tests/Specification/EmailAddressIsFromAProviderSpecificationTest.php
+++ b/tests/Specification/EmailAddressIsFromAProviderSpecificationTest.php
@@ -19,7 +19,7 @@ class EmailAddressIsFromAProviderSpecificationTest extends TestCase
         self::assertSame($isSatisfiedBy, $spec->isSatisfiedBy($emailAddress, $providerName, true));
     }
 
-    public function provideEmailAddresses(): iterable
+    public static function provideEmailAddresses(): iterable
     {
         yield ['invalid email', '', false];
         yield ['unknow provider', 'provider that does not exist', false];

--- a/tests/Translatable/BounceReasonTranslatableTest.php
+++ b/tests/Translatable/BounceReasonTranslatableTest.php
@@ -26,7 +26,7 @@ class BounceReasonTranslatableTest extends KernelTestCase
     /**
      * @return iterable<mixed>
      */
-    public function providerTrans(): iterable
+    public static function providerTrans(): iterable
     {
         yield 'code' => [
             '2.2.1 test code',

--- a/tests/Validation/SmtpValidatorTest.php
+++ b/tests/Validation/SmtpValidatorTest.php
@@ -49,7 +49,7 @@ class SmtpValidatorTest extends TestCase
     }
 
     /** @return array{0: string, 1: class-string<ValidationStatusDtoInterface>}[] */
-    public function provideEmailAddresses(): iterable
+    public static function provideEmailAddresses(): iterable
     {
         yield ['this_user_does_not_exist', InvalidAddressDto::class];
         yield ['this_user_does_not_exist@this_domain_does_not_exist', InvalidAddressDto::class];


### PR DESCRIPTION
## Summary
- Made 11 data provider methods static (Rector)
- PHPStan passes with 0 errors

## Test plan
- [x] Rector clean
- [x] PHPStan 0 errors
- [x] PHPUnit passes (39/41 tests pass; 2 SMTP connection failures are pre-existing network issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)