### PR TITLE
Require PHP 8.4 and add PHP 8.5 to test matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.3', '8.4']
+        php-versions: ['8.4', '8.5']
         dependency-versions: [ 'highest', 'lowest' ]
     runs-on: ubuntu-latest
     steps:

--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     "phpstan/phpstan-symfony": "^2"
   },
   "require": {
-    "php": "^8.3",
+    "php": "^8.4",
     "symfony/cache": "^7.0",
     "symfony/contracts": "^2.5|^3.4",
     "phpmailer/phpmailer": "^6.6",


### PR DESCRIPTION
## Summary
- Bump minimum PHP requirement from `^8.3` to `^8.4` in `composer.json`
- Replace PHP 8.3 with PHP 8.5 in the CI test matrix (keeping PHP 8.4)

## Test plan
- [ ] CI passes on PHP 8.4 and 8.5 with lowest/highest dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)